### PR TITLE
Fix movies list count

### DIFF
--- a/EyeOnBuzz/Infrastructure/DataSources/ListDataSource.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/ListDataSource.swift
@@ -26,6 +26,10 @@ class ListDataSource {
     func atIndex(_ index: Int) -> Any {
         return self.list[index]
     }
+    
+    func count() -> Int {
+        return self.list.count
+    }
 
     func processPaginationInfo(_ responseBody: Dictionary<String, Any>) {
         self.page = responseBody[TMDBSession.Body.Pagination.page] as! Int

--- a/EyeOnBuzz/Infrastructure/DataSources/TMDBSession.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/TMDBSession.swift
@@ -16,6 +16,8 @@ class TMDBSession {
     let notificationCenter = NotificationCenter.default
     
     struct Body {
+        static let results = "results"
+
         struct Pagination {
             static let page = "page"
             static let total  = "total_results"

--- a/EyeOnBuzz/Infrastructure/DataSources/UpcomingMoviesDataSource.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/UpcomingMoviesDataSource.swift
@@ -11,14 +11,13 @@ import Foundation
 class UpcomingMoviesDataSource: ListDataSource {
     
     func fetch() {
-        // TODO: Pass API Key on GET request
         self.session.get(url: Router.TheMovieDatabaseAPI.upcomingMovies, parameters: nil, success: { statusCode, headers, response in
             let upcomingMovies = NSMutableArray()
             
             if let fullResponse = response as? Dictionary<String, Any> {
                 self.processPaginationInfo(fullResponse)
                 
-                if let upcomingMoviesResponse = fullResponse["results"] as? [Dictionary<String, Any>] {
+                if let upcomingMoviesResponse = fullResponse[TMDBSession.Body.results] as? [Dictionary<String, Any>] {
                     for upcomingMovieResponse in upcomingMoviesResponse {
                         let upcomingMovie = UpcomingMovie.init(upcomingMovieResponse)
                         

--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
@@ -58,7 +58,7 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return (self.upcomingMoviesDataSource?.total)!
+        return (self.upcomingMoviesDataSource?.count())!
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
It was rendered by using results total instead results size.

Also use `results` constant to unify node names