### PR TITLE
Display genre names in Upcoming Movies screen

### DIFF
--- a/EyeOnBuzz.xcodeproj/project.pbxproj
+++ b/EyeOnBuzz.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0D91636120192734005C0122 /* UpcomingMovie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91636020192734005C0122 /* UpcomingMovie.swift */; };
 		0DA6D46E201E8D8400C18764 /* NVActivityIndicatorView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA6D46D201E8D8400C18764 /* NVActivityIndicatorView.framework */; };
 		0DA6D470201E8DBC00C18764 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */; };
+		0DA6D474201E9C0E00C18764 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D473201E9C0E00C18764 /* Genre.swift */; };
 		0DBC9946200F7D5D006A01B3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */; };
 		0DBC994F200F7D5D006A01B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0DBC994E200F7D5D006A01B3 /* Assets.xcassets */; };
 		0DBC9952200F7D5D006A01B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0DBC9950200F7D5D006A01B3 /* LaunchScreen.storyboard */; };
@@ -70,6 +71,7 @@
 		0D91636020192734005C0122 /* UpcomingMovie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingMovie.swift; sourceTree = "<group>"; };
 		0DA6D46D201E8D8400C18764 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NVActivityIndicatorView.framework; path = Carthage/Build/iOS/NVActivityIndicatorView.framework; sourceTree = "<group>"; };
 		0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
+		0DA6D473201E9C0E00C18764 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		0DBC9942200F7D5D006A01B3 /* EyeOnBuzz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EyeOnBuzz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0DBC994E200F7D5D006A01B3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				0D91636020192734005C0122 /* UpcomingMovie.swift */,
+				0DA6D473201E9C0E00C18764 /* Genre.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -256,9 +259,9 @@
 			children = (
 				0D91635B2019182A005C0122 /* DataSourceTarget.swift */,
 				0DDDB7222016A7A900BF50D3 /* HTTPClient.swift */,
+				0D91635D201919C6005C0122 /* ListDataSource.swift */,
 				0D9163552019103F005C0122 /* TMDBSession.swift */,
 				0D91635920191433005C0122 /* UpcomingMoviesDataSource.swift */,
-				0D91635D201919C6005C0122 /* ListDataSource.swift */,
 			);
 			path = DataSources;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 				0DBC9946200F7D5D006A01B3 /* AppDelegate.swift in Sources */,
 				0DD5D184201D2DB9003180F7 /* Setting.swift in Sources */,
 				0DE8019A201BDC8600461367 /* UpcomingMovieCell.swift in Sources */,
+				0DA6D474201E9C0E00C18764 /* Genre.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EyeOnBuzz.xcodeproj/project.pbxproj
+++ b/EyeOnBuzz.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0DA6D470201E8DBC00C18764 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */; };
 		0DA6D472201E994100C18764 /* GenresDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D471201E994100C18764 /* GenresDataSource.swift */; };
 		0DA6D474201E9C0E00C18764 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D473201E9C0E00C18764 /* Genre.swift */; };
+		0DA6D47A201EA08400C18764 /* GenresRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D479201EA08400C18764 /* GenresRepository.swift */; };
 		0DBC9946200F7D5D006A01B3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */; };
 		0DBC994F200F7D5D006A01B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0DBC994E200F7D5D006A01B3 /* Assets.xcassets */; };
 		0DBC9952200F7D5D006A01B3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0DBC9950200F7D5D006A01B3 /* LaunchScreen.storyboard */; };
@@ -74,6 +75,7 @@
 		0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
 		0DA6D471201E994100C18764 /* GenresDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenresDataSource.swift; sourceTree = "<group>"; };
 		0DA6D473201E9C0E00C18764 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
+		0DA6D479201EA08400C18764 /* GenresRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenresRepository.swift; sourceTree = "<group>"; };
 		0DBC9942200F7D5D006A01B3 /* EyeOnBuzz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EyeOnBuzz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0DBC994E200F7D5D006A01B3 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -168,10 +170,19 @@
 		0D91635F201926F2005C0122 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				0D91636020192734005C0122 /* UpcomingMovie.swift */,
 				0DA6D473201E9C0E00C18764 /* Genre.swift */,
+				0D91636020192734005C0122 /* UpcomingMovie.swift */,
+				0DA6D478201EA06D00C18764 /* Repositories */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		0DA6D478201EA06D00C18764 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				0DA6D479201EA08400C18764 /* GenresRepository.swift */,
+			);
+			path = Repositories;
 			sourceTree = "<group>";
 		};
 		0DBC9939200F7D5D006A01B3 = {
@@ -460,6 +471,7 @@
 				0DA6D472201E994100C18764 /* GenresDataSource.swift in Sources */,
 				0D3B6791201A964500D9A533 /* UpcomingMoviesViewController.swift in Sources */,
 				0D3B6788201A887600D9A533 /* AppNavigationController.swift in Sources */,
+				0DA6D47A201EA08400C18764 /* GenresRepository.swift in Sources */,
 				0DDDB7232016A7A900BF50D3 /* HTTPClient.swift in Sources */,
 				0D91636120192734005C0122 /* UpcomingMovie.swift in Sources */,
 				0DBC9946200F7D5D006A01B3 /* AppDelegate.swift in Sources */,

--- a/EyeOnBuzz.xcodeproj/project.pbxproj
+++ b/EyeOnBuzz.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0D91636120192734005C0122 /* UpcomingMovie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91636020192734005C0122 /* UpcomingMovie.swift */; };
 		0DA6D46E201E8D8400C18764 /* NVActivityIndicatorView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DA6D46D201E8D8400C18764 /* NVActivityIndicatorView.framework */; };
 		0DA6D470201E8DBC00C18764 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */; };
+		0DA6D472201E994100C18764 /* GenresDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D471201E994100C18764 /* GenresDataSource.swift */; };
 		0DA6D474201E9C0E00C18764 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA6D473201E9C0E00C18764 /* Genre.swift */; };
 		0DBC9946200F7D5D006A01B3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */; };
 		0DBC994F200F7D5D006A01B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0DBC994E200F7D5D006A01B3 /* Assets.xcassets */; };
@@ -71,6 +72,7 @@
 		0D91636020192734005C0122 /* UpcomingMovie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingMovie.swift; sourceTree = "<group>"; };
 		0DA6D46D201E8D8400C18764 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NVActivityIndicatorView.framework; path = Carthage/Build/iOS/NVActivityIndicatorView.framework; sourceTree = "<group>"; };
 		0DA6D46F201E8DBC00C18764 /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
+		0DA6D471201E994100C18764 /* GenresDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenresDataSource.swift; sourceTree = "<group>"; };
 		0DA6D473201E9C0E00C18764 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
 		0DBC9942200F7D5D006A01B3 /* EyeOnBuzz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EyeOnBuzz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DBC9945200F7D5D006A01B3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				0D91635D201919C6005C0122 /* ListDataSource.swift */,
 				0D9163552019103F005C0122 /* TMDBSession.swift */,
 				0D91635920191433005C0122 /* UpcomingMoviesDataSource.swift */,
+				0DA6D471201E994100C18764 /* GenresDataSource.swift */,
 			);
 			path = DataSources;
 			sourceTree = "<group>";
@@ -454,6 +457,7 @@
 				0D3B678E201A911700D9A533 /* WrapperContainerViewController.swift in Sources */,
 				0DD5D182201D2CF1003180F7 /* ImageFactory.swift in Sources */,
 				0DDDB71E2016A07600BF50D3 /* Router.swift in Sources */,
+				0DA6D472201E994100C18764 /* GenresDataSource.swift in Sources */,
 				0D3B6791201A964500D9A533 /* UpcomingMoviesViewController.swift in Sources */,
 				0D3B6788201A887600D9A533 /* AppNavigationController.swift in Sources */,
 				0DDDB7232016A7A900BF50D3 /* HTTPClient.swift in Sources */,

--- a/EyeOnBuzz/Infrastructure/DataSources/DataSourceTarget.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/DataSourceTarget.swift
@@ -12,6 +12,7 @@ struct DataSource {
     
     enum RefreshSource {
         case dontCare
+        case genreList
     }
     
     enum RefreshStatus {

--- a/EyeOnBuzz/Infrastructure/DataSources/GenresDataSource.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/GenresDataSource.swift
@@ -1,0 +1,47 @@
+//
+//  GenresDataSource.swift
+//  EyeOnBuzz
+//
+//  Created by Weverton Couto Timoteo on 1/28/18.
+//  Copyright © 2018 Weverton Couto Timoteo. All rights reserved.
+//
+
+import Foundation
+
+class GenresDataSource {
+    
+    let session = TMDBSession.init()
+    let resultsNodeName = "genres"
+    let dataSourceTarget: DataSourceTarget
+    
+    var list = [Int: String]()
+    
+    init(dataSourceTarget: DataSourceTarget) {
+        self.dataSourceTarget = dataSourceTarget
+    }
+    
+    func fetch() {
+        self.session.get(url: Router.TheMovieDatabaseAPI.genres, parameters: nil, success: { statusCode, headers, response in
+            DispatchQueue.main.async {
+                if let fullResponse = response as? Dictionary<String, Any> {
+                    if let genresResponse = fullResponse[self.resultsNodeName] as? [Dictionary<String, Any>] {
+                        for genreResponse in genresResponse {
+                            let genre = Genre.init(genreResponse)
+                            
+                            self.list[genre.identifier] = genre.name
+                        }
+                    }
+                }
+                
+                self.dataSourceTarget.dataRefreshed(source: DataSource.RefreshSource.genreList, status: DataSource.RefreshStatus.success)
+            }
+        }, failure: { statusCode, response in
+            DispatchQueue.main.async {
+                self.dataSourceTarget.dataRefreshed(source: DataSource.RefreshSource.genreList, status: DataSource.RefreshStatus.failure)
+            }
+        })
+    }
+
+
+    
+}

--- a/EyeOnBuzz/Infrastructure/DataSources/ListDataSource.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/ListDataSource.swift
@@ -11,7 +11,7 @@ import Foundation
 class ListDataSource {
     
     let session = TMDBSession.init()
-    let targetTable: DataSourceTarget
+    let dataSourceTarget: DataSourceTarget
     
     var list: Array<Any> = []
     
@@ -19,8 +19,8 @@ class ListDataSource {
     var total: Int = 0
     var totalPages: Int = 0
     
-    init(targetTable: DataSourceTarget) {
-        self.targetTable = targetTable
+    init(dataSourceTarget: DataSourceTarget) {
+        self.dataSourceTarget = dataSourceTarget
     }
     
     func atIndex(_ index: Int) -> Any {

--- a/EyeOnBuzz/Infrastructure/DataSources/UpcomingMoviesDataSource.swift
+++ b/EyeOnBuzz/Infrastructure/DataSources/UpcomingMoviesDataSource.swift
@@ -29,11 +29,11 @@ class UpcomingMoviesDataSource: ListDataSource {
                     }
                 }
                 
-                self.targetTable.dataRefreshed(source: DataSource.RefreshSource.dontCare, status: DataSource.RefreshStatus.success)
+                self.dataSourceTarget.dataRefreshed(source: DataSource.RefreshSource.dontCare, status: DataSource.RefreshStatus.success)
             }
         }, failure: { statusCode, response in
             DispatchQueue.main.async {
-                self.targetTable.dataRefreshed(source: DataSource.RefreshSource.dontCare, status: DataSource.RefreshStatus.failure)
+                self.dataSourceTarget.dataRefreshed(source: DataSource.RefreshSource.dontCare, status: DataSource.RefreshStatus.failure)
             }
         })
     }

--- a/EyeOnBuzz/Infrastructure/Router.swift
+++ b/EyeOnBuzz/Infrastructure/Router.swift
@@ -16,7 +16,7 @@ class Router {
         static let address: String = String(format: "%@%@", Setting.theMovieDatabaseAPIPrefixURL(), version)
         
         static var upcomingMovies: String { return theMovieDatabaseAPIEndpoint("movie/upcoming") }
-        static var genres: String { return theMovieDatabaseAPIEndpoint("/genre/movie/list") }
+        static var genres: String { return theMovieDatabaseAPIEndpoint("genre/movie/list") }
         
         // MARK: Helpers
         

--- a/EyeOnBuzz/Infrastructure/Router.swift
+++ b/EyeOnBuzz/Infrastructure/Router.swift
@@ -16,6 +16,7 @@ class Router {
         static let address: String = String(format: "%@%@", Setting.theMovieDatabaseAPIPrefixURL(), version)
         
         static var upcomingMovies: String { return theMovieDatabaseAPIEndpoint("movie/upcoming") }
+        static var genres: String { return theMovieDatabaseAPIEndpoint("/genre/movie/list") }
         
         // MARK: Helpers
         

--- a/EyeOnBuzz/Models/Genre.swift
+++ b/EyeOnBuzz/Models/Genre.swift
@@ -1,0 +1,19 @@
+//
+//  Genre.swift
+//  EyeOnBuzz
+//
+//  Created by Weverton Couto Timoteo on 1/28/18.
+//  Copyright © 2018 Weverton Couto Timoteo. All rights reserved.
+//
+
+class Genre {
+    
+    let identifier: Int
+    let name: String
+    
+    init(_ genreInfo: Dictionary<String, Any>) {
+        self.identifier = genreInfo["id"] as! Int
+        self.name = genreInfo["name"] as! String
+    }
+    
+}

--- a/EyeOnBuzz/Models/Repositories/GenresRepository.swift
+++ b/EyeOnBuzz/Models/Repositories/GenresRepository.swift
@@ -1,0 +1,36 @@
+//
+//  GenresRepository.swift
+//  EyeOnBuzz
+//
+//  Created by Weverton Couto Timoteo on 1/28/18.
+//  Copyright © 2018 Weverton Couto Timoteo. All rights reserved.
+//
+
+private class GenresRepositorySetupHelper {
+    
+    var list = [Int: String]()
+    
+    init() {}
+    
+}
+
+final class GenresRepository {
+    
+    static let sharedInstance = GenresRepository()
+    private static let setup = GenresRepositorySetupHelper()
+    
+    var list = [Int: String]()
+    
+    class func setup(list: [Int: String]) {
+        GenresRepository.setup.list = list
+    }
+    
+    private init() {
+        self.list = GenresRepository.setup.list
+    }
+    
+    func nameByIdentifier(_ identifier: Int) -> String {
+        return self.list[identifier]!
+    }
+    
+}

--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMovieCell.swift
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMovieCell.swift
@@ -27,10 +27,19 @@ class UpcomingMovieCell: UITableViewCell {
         self.title?.text = upcomingMovie.title
         self.releaseDate?.text = upcomingMovie.releaseDate
         
-        // TODO: Use GenreList to identify main genre by ID
-        self.genre?.text = String.init(describing: upcomingMovie.genreIdentifiers.first)
+        self.genre?.text = fetchGenreNames(upcomingMovie.genreIdentifiers)
         
         self.posterImage?.image = TMDBImageFactory.fromPath(upcomingMovie.posterPath)
+    }
+    
+    func fetchGenreNames(_ genreIdentifiers: Array<Int>) -> String {
+        var genreNames = Array<String>()
+        
+        for genreIdentifier in genreIdentifiers {
+            genreNames.append(GenresRepository.sharedInstance.nameByIdentifier(genreIdentifier))
+        }
+        
+        return genreNames.joined(separator: ", ")
     }
     
 }

--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMovieCell.xib
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMovieCell.xib
@@ -26,7 +26,7 @@
                             <constraint firstAttribute="height" constant="138" id="qXI-MO-g4F"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="myE-wO-9TP">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="myE-wO-9TP">
                         <rect key="frame" x="102" y="5" width="209" height="56"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="56" id="ah7-ZW-MWX"/>
@@ -45,15 +45,18 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kDE-Sp-lBG" userLabel="ReleaseDate">
-                        <rect key="frame" x="102" y="87" width="209" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kDE-Sp-lBG" userLabel="ReleaseDate">
+                        <rect key="frame" x="102" y="81" width="209" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="209" id="YDl-re-cJx"/>
+                            <constraint firstAttribute="height" constant="21" id="z3n-Hs-ejD"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Genre" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Rn-K5-qMG" userLabel="GenreLabel">
-                        <rect key="frame" x="102" y="104" width="42" height="21"/>
+                        <rect key="frame" x="102" y="101" width="42" height="21"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="21" id="OiX-YT-80i"/>
                             <constraint firstAttribute="width" constant="42" id="S7u-8c-hhH"/>
@@ -65,17 +68,20 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sRq-1d-M87" userLabel="Genre">
                         <rect key="frame" x="102" y="116" width="209" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="0Rn-K5-qMG" firstAttribute="top" secondItem="MFa-lG-itm" secondAttribute="bottom" constant="20" id="3zw-T4-p5O"/>
+                    <constraint firstItem="0Rn-K5-qMG" firstAttribute="top" secondItem="MFa-lG-itm" secondAttribute="bottom" constant="17" id="3zw-T4-p5O"/>
                     <constraint firstAttribute="trailing" secondItem="myE-wO-9TP" secondAttribute="trailing" constant="9" id="CUt-sI-3wA"/>
                     <constraint firstItem="MFa-lG-itm" firstAttribute="leading" secondItem="Rq9-pK-D9a" secondAttribute="trailing" constant="5" id="IVL-H2-obg"/>
+                    <constraint firstItem="kDE-Sp-lBG" firstAttribute="top" secondItem="MFa-lG-itm" secondAttribute="bottom" constant="-3" id="Jra-dj-F8G"/>
+                    <constraint firstAttribute="trailing" secondItem="kDE-Sp-lBG" secondAttribute="trailing" constant="9" id="KRr-LW-mU5"/>
                     <constraint firstItem="Rq9-pK-D9a" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="5" id="VhF-HD-Bfh"/>
                     <constraint firstItem="Rq9-pK-D9a" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="5" id="diG-CW-KWg"/>
+                    <constraint firstItem="kDE-Sp-lBG" firstAttribute="leading" secondItem="Rq9-pK-D9a" secondAttribute="trailing" constant="5" id="dtv-yu-Wch"/>
                     <constraint firstItem="0Rn-K5-qMG" firstAttribute="leading" secondItem="Rq9-pK-D9a" secondAttribute="trailing" constant="5" id="elW-4H-cos"/>
                     <constraint firstItem="myE-wO-9TP" firstAttribute="leading" secondItem="Rq9-pK-D9a" secondAttribute="trailing" constant="5" id="qeh-UG-kdW"/>
                     <constraint firstItem="MFa-lG-itm" firstAttribute="top" secondItem="myE-wO-9TP" secondAttribute="bottom" constant="2" id="qo0-9Y-59I"/>

--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
@@ -19,7 +19,7 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     init() {
         super.init(nibName: nil, bundle: nil)
         
-        self.upcomingMoviesDataSource = UpcomingMoviesDataSource.init(targetTable: self)
+        self.upcomingMoviesDataSource = UpcomingMoviesDataSource.init(dataSourceTarget: self)
         
         self.tableView.accessibilityLabel = "Upcoming Movies"
         self.tableView.register(UINib.init(nibName: "UpcomingMovieCell", bundle: nil), forCellReuseIdentifier: self.cellIdentifier)

--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     
+    var genresDataSource: GenresDataSource?
     var upcomingMoviesDataSource: UpcomingMoviesDataSource?
     
     let numberOfSections: Int = 1
@@ -19,6 +20,7 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     init() {
         super.init(nibName: nil, bundle: nil)
         
+        self.genresDataSource = GenresDataSource.init(dataSourceTarget: self)
         self.upcomingMoviesDataSource = UpcomingMoviesDataSource.init(dataSourceTarget: self)
         
         self.tableView.accessibilityLabel = "Upcoming Movies"
@@ -42,7 +44,7 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     }
     
     func updateData() {
-        self.upcomingMoviesDataSource?.fetch()
+        self.genresDataSource?.fetch()
     }
     
     override func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -61,11 +63,19 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
     // MARK: - DataSourceTarget Protocol
     
     func dataRefreshed(source: DataSource.RefreshSource, status: DataSource.RefreshStatus) {
-        self.tableView.reloadData()
+        if source == DataSource.RefreshSource.genreList {
+            GenresRepository.setup(list: (self.genresDataSource?.list)!)
+            
+            self.upcomingMoviesDataSource?.fetch()
+        }
         
-        LoadingIndicator.stop()
-        
-        self.tableView.refreshControl?.endRefreshing()
+        if source == DataSource.RefreshSource.dontCare {
+            self.tableView.reloadData()
+            
+            LoadingIndicator.stop()
+            
+            self.tableView.refreshControl?.endRefreshing()
+        }
     }
     
     // MARK: UITableViewDataSource


### PR DESCRIPTION
Fetch genre list endpoint before fetch upcoming movies (need to improve to fetch both endpoints but only render table when receive all responses).

- [x] Fix font size for `UpcomingMovieCell`
- [x] Rename `targetTable` to `dataSourceTarget` as its possible to fetch data from anywhere
- [x] Add genres endpoint to Router
- [x] Introduce Genre model
- [x] Implement `GenresDataSource` to fetch genres list
- [x] Introduce `GenresRepository` (to be possible to access genre list from anywhere)
- [x] Render `UpcomingMovieCell` genres based in fetched genres list

![simulator screen shot - iphone se - 2018-01-28 at 23 12 52](https://user-images.githubusercontent.com/645452/35489830-b67761ba-0481-11e8-9e3e-1923ac4e1bbf.png)


