### PR TITLE
Fix undue GET request on back to list screen

### DIFF
--- a/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
+++ b/EyeOnBuzz/Screens/UpcomingMovies/UpcomingMoviesViewController.swift
@@ -35,9 +35,7 @@ class UpcomingMoviesViewController: UITableViewController, DataSourceTarget {
         super.viewDidLoad()
         
         self.setupAppearance()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
+        
         LoadingIndicator.start()
         
         self.updateData()


### PR DESCRIPTION
When returning to upcoming movies screen it was triggering a HTTP GET request for next upcoming movies page.